### PR TITLE
Updates from Zijun Xu

### DIFF
--- a/rtl/AtlasRd53RdReg.vhd
+++ b/rtl/AtlasRd53RdReg.vhd
@@ -72,7 +72,10 @@ begin
       begin
          -- Move the data
          v.configMaster.tValid             := '1';
-         v.configMaster.tData(63 downto 0) := rxData(index);
+         --v.configMaster.tData(63 downto 0) := rxData(index);
+		 --reverse the 64bit frame. So, in YARR software, will receive the rxData(63 downto 32) first, so will know ZZ at first
+         v.configMaster.tData(63 downto 32) := rxData(index)(31 downto  0);
+         v.configMaster.tData(31 downto  0) := rxData(index)(63 downto 32);
          -- Set the End of Frame (EOF) flag
          v.configMaster.tLast              := '1';
          -- Set Start of Frame (SOF) flag

--- a/rtl/AuroraRxChannel.vhd
+++ b/rtl/AuroraRxChannel.vhd
@@ -276,7 +276,9 @@ begin
                elsif (header(r.cnt) = "10") then
 
                   -- Check for data in service header
-                  if (data(r.cnt)(63 downto 32) = x"1E04_0000") then
+                  --if (data(r.cnt)(63 downto 32) = x"1E04_0000") then 
+				  -- RD53a manual is wrong
+                  if (data(r.cnt)(63 downto 48) = x"1E04") then
                      -- Move the data
                      v.dataMaster.tValid              := r.enable(r.cnt);
                      v.dataMaster.tData(63 downto 32) := x"FFFF_FFFF";


### PR DESCRIPTION
### Description
- real RD53a chip is diff from RD53a Manual
- reverse the two 32bits in the 64 bit frame, so that the software can see the original bit 63-32 at first; should have better way to solve this issue